### PR TITLE
changed script indentifier from sh to bash

### DIFF
--- a/make_manifest
+++ b/make_manifest
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 release_dir=$(dirname $0)
 templates=$release_dir/templates


### PR DESCRIPTION
On my Ubuntu 14 machine, make_manifest returns an error:

```
./make_manifest: 17: [: warden: unexpected operator
2014/08/20 13:51:42 error generating manifest: unresolved nodes:
    (( merge )) in ./templates/admin-ui-deployment.yml  director_uuid
```

I believe it's caused because the script uses Bash notation for an "if" statement while it declares itself to be a /bin/sh script. Ubuntu 14 maps /bin/sh to dash, which doesn't support this notation. Declaring it as /bin/bash solves the problem.
