### PR TITLE
use mktemp instead of $TMPDIR

### DIFF
--- a/make_manifest
+++ b/make_manifest
@@ -22,8 +22,7 @@ if [ "$infrastructure" == "warden" ] ; then
     exit 1
   fi
 
-  temp_dir=$TMPDIR/admin_ui-$$.tmp
-  mkdir -p $temp_dir
+  temp_dir=$(mktemp -d admin_ui-XXXXXXXXXX) || { echo "Failed to create temp file"; exit 1; }
 
   bosh -q download manifest cf-warden $temp_dir/cf-warden.yml
   sed -i.back 's/!//g' $temp_dir/cf-warden.yml


### PR DESCRIPTION
Running this script on my Ubuntu 14 server gives a permission denied error:
It tries to create a temp dir using $TMPDIR which is not set in my shell, and as I'm not running it as root, it fails to create `/admin_ui-12322.tmp`.
Using mktemp, which defaults to $TMPDIR if set, else to /tmp, solves it.
