### PR TITLE
Add mysql support to admin_ui job.

### DIFF
--- a/jobs/admin_ui/spec
+++ b/jobs/admin_ui/spec
@@ -10,6 +10,7 @@ packages:
   - ruby
   - libyaml
   - libpq
+  - mysqlclient
   - common
 
 properties:


### PR DESCRIPTION
Admin UI is not able to work with mysql database of CC/UAA because mysqlclient is not specified in admin_ui job dependencies.

Package dependencies are used only during compile time.