### PR TITLE
Update admin UI to the latest source

### DIFF
--- a/jobs/admin_ui/templates/admin_ui.yml.erb
+++ b/jobs/admin_ui/templates/admin_ui.yml.erb
@@ -14,6 +14,7 @@ cloud_controller_uri: <%= p("admin_ui.cloud_controller_uri") %>
 component_connection_retries: 2
 data_file: /var/vcap/store/admin_ui/data.json
 db_uri: sqlite://var/vcap/store/admin_ui/store.db
+event_days: 7
 log_file: /var/vcap/sys/log/admin_ui/admin_ui.log
 log_file_page_size: 51200
 mbus: nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= p("nats.address") %>:<%= p("nats.port") %>


### PR DESCRIPTION
The current source pointer for admin-ui fails on our cf 210 release. Update to the newest admin-ui source and add new config value to the template.