### PR TITLE
register errand: fix for passing multiple users for group assignment

### DIFF
--- a/jobs/register_admin_ui/templates/bin/register_admin_ui
+++ b/jobs/register_admin_ui/templates/bin/register_admin_ui
@@ -42,7 +42,7 @@ roles.each do |role, scopes|
       puts `uaac group add #{scope}`
     end
 
-    members = instance_variable_get("@#{role}").sub(',', ' ')
+    members = instance_variable_get("@#{role}").gsub(',', ' ')
     unless members.empty?
       puts "Adding members: #{members} to group: #{scope}"
       puts `uaac member add #{scope} #{members}`


### PR DESCRIPTION
When adding multiple members to admin and simple user groups, it fails rewriting the user list.

The ruby sub function only alter the first occurence of the pattern. members variable have to be assigned with ruby gsub function and not sub function.