### PR TITLE
Fix including all package bin directories

### DIFF
--- a/jobs/deregister_admin_ui/templates/helpers/ctl_setup.sh
+++ b/jobs/deregister_admin_ui/templates/helpers/ctl_setup.sh
@@ -17,12 +17,13 @@ JOB_NAME=$1
 output_label=${2:-${JOB_NAME}}
 
 export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+export PACKAGE_DIR=/var/vcap/packages/$JOB_NAME
 chmod 755 $JOB_DIR # to access file via symlink
 
 source $JOB_DIR/helpers/ctl_utils.sh
 
-# Add all packages' /bin & /sbin into $PATH
-for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+# Add bin directories from admin_ui and vcap-common
+for package_bin_dir in $(ls -d ${PACKAGE_DIR}/*/bin)
 do
   export PATH=${package_bin_dir}:$PATH
 done


### PR DESCRIPTION
- Including all bin directories under /packages can result in deployment errors depending on which combination of jobs is deployed.  For example, Concourse can use busybox which may bring in a new core utility which does not behave as expected, resulting in a failed deployment
- This change scopes the PATH includes to only use /var/vcap/packages/admin_ui bin directories
