### PR TITLE
Tentative fix for issue #50

### DIFF
--- a/jobs/admin_ui/templates/admin_ui.yml.erb
+++ b/jobs/admin_ui/templates/admin_ui.yml.erb
@@ -22,7 +22,12 @@ log_file_sftp_keys: [ ]
 log_files: [/var/vcap/sys/log/admin_ui/admin_ui.log]
 log_file: /var/vcap/sys/log/admin_ui/admin_ui.log
 log_file_page_size: 51200
-mbus: nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= p("nats.address") %>:<%= p("nats.port") %>
+<% if_p("nats.address") do |address| %>
+mbus: nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= address %>:<%= p("nats.port") %>
+<% end %>
+<% if_p("nats.machines") do |machines| %>
+mbus: nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= machines[0] %>:<%= p("nats.port") %>
+<% end %>
 monitored_components: [NATS, CloudController, DEA, HealthManager, Router, -Provisioner, ALL]
 nats_discovery_interval: 30
 nats_discovery_timeout: 10

--- a/jobs/admin_ui/templates/cf-registrar.config.yml.erb
+++ b/jobs/admin_ui/templates/cf-registrar.config.yml.erb
@@ -4,7 +4,15 @@ logging:
   level: info
 
 message_bus_servers:
-  - nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= p("nats.address") %>:<%= p("nats.port") %>
+<% if_p("nats.address") do |address| %>
+  - nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= address %>:<%= p("nats.port") %>
+<% end %>
+<% if_p("nats.machines") do |machines| %>
+  <% machines.each do |machine| %>        
+  - nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= machine %>:<%= p("nats.port") %>
+  <% end %>
+<% end %>
+
 
 <% if_p("admin_ui.uri") do |uri| %>
 uri:


### PR DESCRIPTION
tentative fix for #50 
enables nats.machines property. Only actually uses all NATS nodes for
route registrar. admin ui itself just uses first NATS server in list

TODO handle case where both nats.machines and nats.address are used